### PR TITLE
update to grid_search return 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.2.2
+Version: 0.2.3
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",
@@ -21,7 +21,11 @@ Authors@R:
       person(given = "John",
            family = "Lees",
            role = c("aut"),
-           email = "j.lees@imperial.ac.uk"))
+           email = "j.lees@imperial.ac.uk"),
+      person(given = "OJ",
+           family = "Watson",
+           role = c("aut"),
+           email = "o.watson15@imperial.ac.uk"))
 Description: Model for COVID-19, using odin.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sircovid 0.2.3
+
+- Add data, model_params and pars_obs to grid search return
+
+# sircovid 0.2.2
+
+- Fixing issues in generate_parameters and changed default parameters
+
 # sircovid 0.2.1
 
 - Adds time varying beta

--- a/R/grid_search.R
+++ b/R/grid_search.R
@@ -117,7 +117,11 @@ scan_beta_date <- function(
   results <- list(x=beta_1D, 
                   y=date_list,
                   mat_log_ll=mat_log_ll,
-                  renorm_mat_LL=renorm_mat_LL)
+                  renorm_mat_LL=renorm_mat_LL,
+                  inputs = list(
+                    model_params = model_params,
+                    pars_obs = pars_obs,
+                    data = data))
   class(results) <- "sircovid_scan"
   results
 }

--- a/tests/testthat/test-grid_search.R
+++ b/tests/testthat/test-grid_search.R
@@ -25,6 +25,8 @@ test_that("Small grid search works", {
     data = data)
    
   expect_is(scan_results, "sircovid_scan")
+  expect_true("inputs" %in% names(scan_results))
+  expect_true(all(names(scan_results$inputs) == c("model_params","pars_obs","data")))
   
   beta_grid = seq(min_beta, max_beta, beta_step)
   date_grid = seq(as.Date(first_start_date), as.Date(last_start_date), day_step)


### PR DESCRIPTION
Update what is output to so that the grid search output can be used to query the parameter space afterwards (i.e. we know the data and parameters used).

Not sure if the version change is needed.