### PR TITLE
fixing beta_t so it matches the correct time scale (time-steps not days)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.2.8
+Version: 0.2.9
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# sircovid 0.2.9
+
+- Fixes a bug with time scaling of beta macthing coding in odin
+
 # sircovid 0.2.8
 
 - sample_grid_scan can now accept forecast_days

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -143,6 +143,7 @@ generate_parameters <- function(
   if (any(diff(beta_dates) < 0)) {
     stop("Supplied dates are not increasing")
   }
+  beta_t <- beta_dates/dt
   
   # 
   # This section defines proportions between partitions
@@ -225,7 +226,7 @@ generate_parameters <- function(
                          trans_increase = trans_increase_array,
                          trans_profile = trans_profile_array,
                          beta_y = beta,
-                         beta_t = beta_dates,
+                         beta_t = beta_t,
                          s_E = progression_groups$E,
                          gamma_E = gammas$E,
                          s_asympt = progression_groups$asympt,

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -59,14 +59,16 @@ test_that("Parameters generated as expected", {
   
   # Test date interpolation, and starts from zero, accounts for leap years (2020)
   beta <- c(0.1, 0.2, 0.3)
+  dt <- 0.25
   test_params <- generate_parameters(beta=beta,
-                                     beta_times=c("2020-03-02", "2020-03-15", "2020-04-01"))
+                                     beta_times=c("2020-03-02", "2020-03-15", "2020-04-01"),
+                                     dt = dt)
   expect_identical(test_params$beta_y, beta)
-  expect_identical(test_params$beta_t, c(0, 13, 30))
+  expect_identical(test_params$beta_t, c(0, 13, 30)/dt)
   
   test_params <- generate_parameters(beta=beta,
                                      beta_times=c("2020-02-02", "2020-02-15", "2020-03-01"))
-  expect_identical(test_params$beta_t, c(0, 13, 28))
+  expect_identical(test_params$beta_t, c(0, 13, 28)/dt)
 })
 
 test_that("Bad inputs", {
@@ -104,9 +106,11 @@ test_that("Time varying betas can be generated", {
   # Test time varying beta can be generated, and goes in and
   # out of generate_parameters() correctly
   beta = generate_beta(0.4, reduction_period = 3)
+  dt <- 0.25
   params = generate_parameters(beta = beta$beta,
-                               beta_times = beta$beta_times)
-  expect_equal(params$beta_t, c(0, 43, 44, 45))
+                               beta_times = beta$beta_times,
+                               dt = dt)
+  expect_equal(params$beta_t, c(0, 43, 44, 45)/dt)
   expect_equal(params$beta_y, c(0.4000, 0.4000, 0.2476, 0.0952))
   
   # Error checking

--- a/tests/testthat/test-sircovid.R
+++ b/tests/testthat/test-sircovid.R
@@ -19,7 +19,7 @@ test_that("Can be run on real data", {
                                                    exp_noise = 1e6),
                                  n_particles = 1000)
   # No check of correctness  
-  expect_equal(results$log_likelihood, -14074.79, tolerance=1e-3)
+  expect_equal(results$log_likelihood, -269.9478, tolerance=1e-3)
 })
 
 test_that("Poor formatting of real data errors", {


### PR DESCRIPTION
Before the values in beta_t were on a time-scale in terms of days, but this is used in the model on a time-scale of time-steps of length dt, so beta_t needs to be on that time-scale.

Hence scale beta_t by 1/dt.