### PR TITLE
plot daily deaths not cumulative

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.2.11
+Version: 0.2.12
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# sircovid 0.2.12
+
+- When doing grid sample and projections plot deaths counts rather than cumulative
+
 # sircovid 0.2.11
 
 - Adds pMCMC for beta and start date inference

--- a/R/grid_search.R
+++ b/R/grid_search.R
@@ -151,7 +151,9 @@ plot.sample_grid_search <- function(x, ..., what = "ICU") {
     index <- c(odin_index(x$inputs$model)$D) - 1L
     ylab <- "Deaths"
     particles <- vapply(seq_len(dim(x$trajectories)[3]), function(y) {
-      rowSums(x$trajectories[,index,y], na.rm = TRUE)}, 
+      out <- c(0,diff(rowSums(x$trajectories[,index,y], na.rm = TRUE)))
+      names(out)[1] <- rownames(x$trajectories)[1]
+      out}, 
       FUN.VALUE = numeric(dim(x$trajectories)[1]))
     plot_particles(particles, ylab = ylab)
     points(as.Date(x$inputs$data$date), 

--- a/R/grid_search.R
+++ b/R/grid_search.R
@@ -154,7 +154,8 @@ plot.sample_grid_search <- function(x, ..., what = "ICU") {
       rowSums(x$trajectories[,index,y], na.rm = TRUE)}, 
       FUN.VALUE = numeric(dim(x$trajectories)[1]))
     plot_particles(particles, ylab = ylab)
-    points(as.Date(x$inputs$data$date), cumsum(x$inputs$data$deaths), pch = 19)
+    points(as.Date(x$inputs$data$date), 
+           x$inputs$data$deaths/ x$inputs$pars_obs$phi_death, pch = 19)
     
   } else {
     


### PR DESCRIPTION
Plotting daily deaths rather than cumulative - note that the plotted deaths data are now quite far outside of the projections produced by the https://github.com/ncov-ic/ncov-outputs/tree/rtm_itu_deaths_for_sircovid/src/rtm_inference_sircovid task
