### PR TITLE
adding save_end_states option to particle_filter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.2.12
+Version: 0.2.13
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# sircovid 0.2.13
+
+- Adds a save_end_states option to particle_filter
+
+
 # sircovid 0.2.12
 
 - When doing grid sample and projections plot deaths counts rather than cumulative

--- a/R/sampler.R
+++ b/R/sampler.R
@@ -21,7 +21,7 @@
 ##'  single particle, chosen at random, at the final time point for which 
 ##'  we have data
 ##'  
-##'  @param save_end_states Logical, indicating whether we should save all
+##' @param save_end_states Logical, indicating whether we should save all
 ##'  particles at the final time point for which we have data
 ##'   
 ##' @export

--- a/R/sampler.R
+++ b/R/sampler.R
@@ -44,6 +44,9 @@ particle_filter <- function(data, model, compare, n_particles,
   if (forecast_days < 0) {
     stop("forecast_days must be positive")
   }
+  if (save_particles && save_end_states){
+    stop("Can not have both save_particles and save_end_states input as TRUE")
+  }
 
   i_state <- seq_along(model$initial()) + 1L
 

--- a/R/sampler.R
+++ b/R/sampler.R
@@ -20,12 +20,15 @@
 ##' @param save_sample_state Logical, indicating whether we should save a
 ##'  single particle, chosen at random, at the final time point for which 
 ##'  we have data
+##'  
+##'  @param save_end_states Logical, indicating whether we should save all
+##'  particles at the final time point for which we have data
 ##'   
 ##' @export
 ##' 
 particle_filter <- function(data, model, compare, n_particles,
                             forecast_days = 0, save_particles = FALSE, 
-                            save_sample_state = FALSE) {
+                            save_sample_state = FALSE, save_end_states = FALSE) {
   if (!inherits(data, "particle_filter_data")) {
     stop("Expected a data set derived from particle_filter_data")
   }
@@ -111,6 +114,9 @@ particle_filter <- function(data, model, compare, n_particles,
   if (save_sample_state) {
     particle_chosen <- sample.int(n = n_particles, size = 1)
     ret$sample_state <- state[, particle_chosen]
+  }
+  if (save_end_states){
+    ret$states <- state
   }
   ret
 }

--- a/man/generate_parameters.Rd
+++ b/man/generate_parameters.Rd
@@ -8,10 +8,10 @@ generate_parameters(
   transmission_model = "POLYMOD",
   country = "United Kingdom",
   severity_data_file = NULL,
-  progression_groups = list(E = 2, asympt = 1, mild = 1, ILI = 1, hosp = 2, ICU = 2, rec
-    = 2),
-  gammas = list(E = 1/(4.59/2), asympt = 1/2.09, mild = 1/2.09, ILI = 1/4, hosp = 2, ICU
-    = 2/5, rec = 2/5),
+  progression_groups = list(E = 2, asympt = 1, mild = 1, ILI = 1, hosp = 2, ICU = 2,
+    rec = 2),
+  gammas = list(E = 1/(4.59/2), asympt = 1/2.09, mild = 1/2.09, ILI = 1/4, hosp = 2,
+    ICU = 2/5, rec = 2/5),
   infection_seeding = list(values = c(10), bins = c("15 to 19")),
   beta = c(0.1, 0.1, 0.1),
   beta_times = c("2020-02-02", "2020-03-01", "2020-04-01"),

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -11,7 +11,8 @@ particle_filter(
   n_particles,
   forecast_days = 0,
   save_particles = FALSE,
-  save_sample_state = FALSE
+  save_sample_state = FALSE,
+  save_end_states = FALSE
 )
 }
 \arguments{
@@ -32,7 +33,10 @@ histories (this is slower).}
 
 \item{save_sample_state}{Logical, indicating whether we should save a
 single particle, chosen at random, at the final time point for which 
-we have data}
+we have data
+
+@param save_end_states Logical, indicating whether we should save all
+particles at the final time point for which we have data}
 }
 \description{
 Run a particle filter

--- a/man/particle_filter.Rd
+++ b/man/particle_filter.Rd
@@ -33,9 +33,9 @@ histories (this is slower).}
 
 \item{save_sample_state}{Logical, indicating whether we should save a
 single particle, chosen at random, at the final time point for which 
-we have data
+we have data}
 
-@param save_end_states Logical, indicating whether we should save all
+\item{save_end_states}{Logical, indicating whether we should save all
 particles at the final time point for which we have data}
 }
 \description{


### PR DESCRIPTION
When we run the particle filter within the SMC^2 algorithm, need to output all the end states (along with the log-likelihood). Can extract this with the save_particles option, but the save_end_states option is faster and saves on memory.