### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - master
-      - fix-release
 
 name: make-release
 

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Extract version
         run: |
-          echo "version=$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')" >> GITHUB_ENV
+          echo "version=$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
           echo "name=$(grep '^Package' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
 
       - uses: actions/download-artifact@v2

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -82,8 +82,8 @@ jobs:
 
       - name: Extract version
         run: |
-          echo "version=$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
-          echo "name=$(grep '^Package' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
+          echo "PACKAGE_VERSION=$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
+          echo "PACKAGE_NAME=$(grep '^Package' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - fix-release
 
 name: make-release
 
@@ -81,8 +82,8 @@ jobs:
 
       - name: Extract version
         run: |
-          echo "::set-env name=PACKAGE_VERSION::$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')"
-          echo "::set-env name=PACKAGE_NAME::$(grep '^Package' DESCRIPTION  | sed 's/.*: *//')"
+          echo "version=$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')" >> GITHUB_ENV
+          echo "name=$(grep '^Package' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
 
       - uses: actions/download-artifact@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.7.0
+Version: 0.7.1
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.7.1
+Version: 0.7.0
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",


### PR DESCRIPTION
github has deprecated the old way of propagating environment variables across builds; this updates to use the new approach. Tested by running against this branch then purging the release.

https://github.com/mrc-ide/sircovid/runs/1423974696
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/