### PR TITLE
Faster eigenvalues through better defaults

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.9.14
+Version: 0.9.15
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/carehomes_rt.R
+++ b/R/carehomes_rt.R
@@ -115,7 +115,7 @@ carehomes_Rt <- function(step, S, p, prob_strain = NULL, type = NULL) {
         i_gen <- seq_len(nrow(ngm))[-c(i_CHW, i_CHR)]
         ngm <- ngm[i_gen, i_gen]
       }
-      ev <- eigen(ngm)$values
+      ev <- eigen(ngm, FALSE, TRUE)$values
       ev[Im(ev) != 0] <- NA
       ev <- as.numeric(ev)
       out <- max(ev, na.rm = TRUE)


### PR DESCRIPTION
I did try with Rspectra (https://cran.r-project.org/web/packages/RSpectra/vignettes/introduction.html) but that was actually slower, even after turning off eigenvectors and selecting only the largest value. Possibly with a bigger matrix that would be better