### PR TITLE
Remove reference to deprecated function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.9.24
+Version: 0.9.25
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/carehomes_ifr_t.R
+++ b/R/carehomes_ifr_t.R
@@ -172,7 +172,7 @@ carehomes_ifr_t <- function(step, S, I_weighted, p, type = NULL) {
 ## We expect 'step' to be a vector along step
 
 ##' Compute "IFR_t" for a set of simulated trajectories (e.g., the result
-##' of [dust::dust_iterate()], [mcstate::pmcmc()] or
+##' of the `$iterate()` method of [carehomes], [mcstate::pmcmc()] or
 ##' [mcstate::pmcmc_predict()]. The trajectories may or may not share
 ##' parameters.
 ##'

--- a/R/carehomes_rt.R
+++ b/R/carehomes_rt.R
@@ -232,7 +232,7 @@ carehomes_Rt <- function(step, S, p, prob_strain = NULL,
 ## We expect 'step' to be a vector along step
 
 ##' Compute "Rt" for a set of simulated trajectories (e.g., the result
-##' of [dust::dust_iterate()], [mcstate::pmcmc()] or
+##' of the `$iterate()` method of [carehomes], [mcstate::pmcmc()] or
 ##' [mcstate::pmcmc_predict()]. The trajectories may or may not share
 ##' parameters.
 ##'

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -19,15 +19,15 @@
 ##'   timescale of the simulation.
 ##'
 ##' @param index A (possibly named) integer vector representing an
-##'   index into the model state that should be returned (see
-##'   [dust::dust_simulate])
+##'   index into the model state that should be returned; will be set
+##'   into the model with `$set_index`
 ##'
 ##' @param n_threads The number of threads to use in the
 ##'   simulation. This only has an effect if your sircovid was built
 ##'   with OpenMP support (possibly not the case on macOS).  Each
 ##'   simulation will be run on potentially a different thread.
 ##'
-##' @param seed Optional seed (see [dust::dust_simulate])
+##' @param seed Optional seed to create the model with
 ##'
 ##' @export
 ##'

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -85,7 +85,7 @@ sircovid_simulate <- function(mod, state, p, events,
 
   rownames(res) <- names(index)
 
-  ## TODO: mcstate::array_drop(state, 2)
+  ## TODO: use mcstate::array_drop(state, 2)
   state <- obj$state()
   dim(state) <- dim(state)[c(1, 3)]
 

--- a/man/carehomes_Rt_trajectories.Rd
+++ b/man/carehomes_Rt_trajectories.Rd
@@ -74,7 +74,7 @@ matrix, not a vector.
 }
 \description{
 Compute "Rt" for a set of simulated trajectories (e.g., the result
-of \code{\link[dust:dust_iterate]{dust::dust_iterate()}}, \code{\link[mcstate:pmcmc]{mcstate::pmcmc()}} or
+of the \verb{$iterate()} method of \link{carehomes}, \code{\link[mcstate:pmcmc]{mcstate::pmcmc()}} or
 \code{\link[mcstate:pmcmc_predict]{mcstate::pmcmc_predict()}}. The trajectories may or may not share
 parameters.
 }

--- a/man/carehomes_ifr_t_trajectories.Rd
+++ b/man/carehomes_ifr_t_trajectories.Rd
@@ -47,7 +47,7 @@ matrix, not a vector.
 }
 \description{
 Compute "IFR_t" for a set of simulated trajectories (e.g., the result
-of \code{\link[dust:dust_iterate]{dust::dust_iterate()}}, \code{\link[mcstate:pmcmc]{mcstate::pmcmc()}} or
+of the \verb{$iterate()} method of \link{carehomes}, \code{\link[mcstate:pmcmc]{mcstate::pmcmc()}} or
 \code{\link[mcstate:pmcmc_predict]{mcstate::pmcmc_predict()}}. The trajectories may or may not share
 parameters.
 }

--- a/man/sircovid_simulate.Rd
+++ b/man/sircovid_simulate.Rd
@@ -29,15 +29,15 @@ data, representing changes in the parameters, and the overall
 timescale of the simulation.}
 
 \item{index}{A (possibly named) integer vector representing an
-index into the model state that should be returned (see
-\link[dust:dust_simulate]{dust::dust_simulate})}
+index into the model state that should be returned; will be set
+into the model with \verb{$set_index}}
 
 \item{n_threads}{The number of threads to use in the
 simulation. This only has an effect if your sircovid was built
 with OpenMP support (possibly not the case on macOS).  Each
 simulation will be run on potentially a different thread.}
 
-\item{seed}{Optional seed (see \link[dust:dust_simulate]{dust::dust_simulate})}
+\item{seed}{Optional seed to create the model with}
 }
 \value{
 A 3-d array with dimensions representing state (along

--- a/tests/testthat/helper-ifr_t.R
+++ b/tests/testthat/helper-ifr_t.R
@@ -16,7 +16,8 @@ reference_data_ifr_t <- function() {
     steps <- seq(initial$step, end, by = 1 / p$dt)
 
     set.seed(1)
-    y <- dust::dust_iterate(mod, steps, index)
+    mod$set_index(index)
+    y <- mod$simulate(steps)
     S <- y[seq_len(length(index_S)), , ]
     I_weighted <- y[-seq_len(length(index_S)), , ]
 

--- a/tests/testthat/helper-rt.R
+++ b/tests/testthat/helper-rt.R
@@ -14,7 +14,8 @@ reference_data_rt <- function() {
     steps <- seq(initial$step, end, by = 1 / p$dt)
 
     set.seed(1)
-    y <- dust::dust_iterate(mod, steps, index)
+    mod$set_index(index)
+    y <- mod$simulate(steps)
     rt_1 <- carehomes_Rt(steps, y[, 1, ], p)
     rt_all <- carehomes_Rt_trajectories(steps, y, p)
 

--- a/tests/testthat/test-basic-check.R
+++ b/tests/testthat/test-basic-check.R
@@ -5,8 +5,8 @@ test_that("N_tot stays constant", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  n_tot <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$N_tot)
+  mod$set_index(info$index$N_tot)
+  n_tot <- mod$simulate(seq(0, 400, by = 4))
   expect_true(all(n_tot == sum(p$population)))
 })
 
@@ -16,8 +16,8 @@ test_that("there are no infections when beta is 0", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  s <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$S)
+  mod$set_index(info$index$S)
+  s <- mod$simulate(seq(0, 400, by = 4))
 
   ## Susceptible population is never drawn down:
   expect_equal(s, array(s[, , 1], c(17, 1, 101)))
@@ -29,8 +29,8 @@ test_that("everyone is infected when beta is very high", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  s <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$S)
+  mod$set_index(info$index$S)
+  s <- mod$simulate(seq(0, 400, by = 4))
   expect_true(all(s[, , -1] == 0))
 })
 
@@ -42,8 +42,8 @@ test_that("No one is infected if I and E are 0 at t = 0", {
   y <- basic_initial(info, 1, p)$state
   y[info$index$I_A] <- 0
   mod$set_state(y)
-  mod$set_index(integer(0))
-  s <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$S)
+  mod$set_index(info$index$S)
+  s <- mod$simulate(seq(0, 400, by = 4))
 
   ## Susceptible population is never drawn down:
   expect_equal(s, array(s[, , 1], c(17, 1, 101)))
@@ -57,9 +57,8 @@ test_that("No one is hospitalised if p_C is 0", {
 
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(any(y$E > 0))
   expect_true(all(y$I_C == 0))
@@ -78,9 +77,8 @@ test_that("No one goes to ICU and no deaths if p_recov_hosp is 1", {
 
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    mod$simulate(seq(0, 400, by = 4)))
 
   expect_true(any(y$I_hosp > 0))
   expect_true(all(y$I_ICU == 0))
@@ -97,9 +95,8 @@ test_that("p_death_hosp = 1, p_recov_hosp = 0: no icu, no recovery", {
 
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(any(y$I_hosp > 0))
   expect_true(all(y$I_ICU == 0))
@@ -115,9 +112,8 @@ test_that("if p_recov_ICU = 0, no-one recovers in hospital", {
 
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(any(y$I_hosp > 0))
   expect_true(all(y$R_hosp == 0))
@@ -131,10 +127,9 @@ test_that("if gamma_E is Inf, E cases must progress in 1 timestep", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   ## NOTE: movement is in one *timestep* not one *day*, so can't use
   ## "by = 4" here to get daily output (and in similar tests below)
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   i <- seq_len(dim(y$E)[[4]] - 1)
   j <- i + 1L
@@ -153,8 +148,7 @@ test_that("if gamma_A is Inf, I_A must progress in 1 timestep", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <-  mod$transform_variables(drop(mod$simulate(0:400)))
 
   i <- seq_len(dim(y$I_A)[[4]] - 1)
   j <- i + 1L
@@ -173,8 +167,7 @@ test_that("if gamma_C is Inf, I_C cases must progress in 1 timestep", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   i <- seq_len(dim(y$I_C)[[4]] - 1)
   j <- i + 1L
@@ -193,8 +186,7 @@ test_that("if gamma_hosp is Inf, I_hosp cases must progress in 1 timestep", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   i <- seq_len(dim(y$I_hosp)[[4]] - 1)
   j <- i + 1L
@@ -213,8 +205,7 @@ test_that("if gamma_ICU is Inf, I_ICU cases must progress in 1 timestep", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   i <- seq_len(dim(y$I_ICU)[[4]] - 1)
   j <- i + 1L
@@ -232,8 +223,7 @@ test_that("if gamma_rec is Inf, R_hosp cases must progress in 1 time-step", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   i <- seq_len(dim(y$R_hosp)[[4]] - 1)
   j <- i + 1L
@@ -249,10 +239,9 @@ test_that("if gamma_E is 0, E stay in progression stage 1", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   ## NOTE: movement is in one *timestep* not one *day*, so can't use
   ## "by = 4" here to get daily output (and in similar tests below)
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   expect_true(any(y$E[, 1, , ] > 0))
   expect_true(all(y$E[, 2, , ] == 0))
@@ -267,8 +256,7 @@ test_that("if gamma_A is 0, I_A stay in progression stage 1", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   expect_true(any(y$I_A[, 1, , ] > 0))
   expect_true(all(y$I_A[, 2, , ] == 0))
@@ -283,8 +271,7 @@ test_that("if gamma_C is 0, I_C stay in progression stage 1", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   expect_true(any(y$I_C[, 1, , ] > 0))
   expect_true(all(y$I_C[, 2, , ] == 0))
@@ -298,8 +285,7 @@ test_that("if gamma_hosp is 0, I_hosp stay in progression stage 1", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   expect_true(any(y$I_hosp[, 1, , ] > 0))
   expect_true(all(y$I_hosp[, 2, , ] == 0))
@@ -313,8 +299,7 @@ test_that("if gamma_ICU is 0, I_ICU stay in progression stage 1", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   expect_true(any(y$I_ICU[, 1, , ] > 0))
   expect_true(all(y$I_ICU[, 2, , ] == 0))
@@ -328,8 +313,7 @@ test_that("if gamma_ICU is 0, I_ICU stay in progression stage 1", {
   mod <- basic$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(basic_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   expect_true(any(y$R_hosp[, 1, , ] > 0))
   expect_true(all(y$R_hosp[, 2, , ] == 0))

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -54,7 +54,8 @@ test_that("incidence calculation is correct", {
   expect_length(index, 2) # guard against name changes
 
   steps <- seq(initial$step, length.out = 60 * 4 + 1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
 
   i <- which(steps %% pars$steps_per_day == 0)
   y0 <- y[, , i[-length(i)]]

--- a/tests/testthat/test-carehomes-check.R
+++ b/tests/testthat/test-carehomes-check.R
@@ -8,9 +8,8 @@ test_that("N_tot, N_tot2 and N_tot3 stay constant", {
   info <- mod$info()
   y0 <- carehomes_initial(info, 1, p)$state
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   ## This is not quite correct, and I don't really know why. I think
   ## that this is the rounding that we're doing to shuffle the
@@ -37,8 +36,8 @@ test_that("there are no infections when beta is 0", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  s <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$S)
+  mod$set_index(info$index$S)
+  s <- mod$simulate(seq(0, 400, by = 4))
 
   ## Susceptible population is never drawn down:
   expect_equal(s, array(s[, , 1], c(nrow(s), 1, 101)))
@@ -50,9 +49,8 @@ test_that("everyone is infected when beta is large", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(drop(
-    dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    mod$simulate(seq(0, 400, by = 4))))
   expect_true(all(y$S[, 1, -1] == 0))
 })
 
@@ -81,9 +79,8 @@ test_that("noone stays in R, T_sero_neg or T_PCR_neg if waning rate is very
   state[index_S] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(drop(
-    dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    mod$simulate(seq(0, 400, by = 4))))
 
   # other than in the 4th age group (where infections are seeded)
   # after the first day (4 times steps), R is empty
@@ -102,9 +99,8 @@ test_that("R, T_sero_neg and T_PCR_neg are all non-decreasing and S is
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(drop(
-    dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(all(diff(t(drop(y$R))) >= 0))
   expect_true(all(diff(t(drop(y$T_sero_neg))) >= 0))
@@ -126,8 +122,8 @@ test_that("No one is infected if I and E are 0 at t = 0", {
   y[info$index$T_PCR_pos] <- 0
 
   mod$set_state(y)
-  mod$set_index(integer(0))
-  s <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$S)
+  mod$set_index(info$index$S)
+  s <- mod$simulate(seq(0, 400, by = 4))
 
   ## Susceptible population is never drawn down:
   expect_equal(s, array(s[, , 1], c(nrow(s), 1, 101)))
@@ -143,9 +139,8 @@ test_that("No one is hospitalised, no-one dies if p_C is 0", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(any(y$E > 0L))
   expect_true(all(y$I_C == 0))
@@ -180,9 +175,8 @@ test_that("No one is hospitalised, no-one dies if psi_H is 0", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(any(y$E > 0L))
   expect_true(any(y$I_C > 0))
@@ -229,9 +223,8 @@ test_that("No one is hospitalised, no-one recovers in edge case", {
   y0[info$index$I_A] <- 0
 
   mod$set_state(y0)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(any(y$I_C > 0))
   expect_true(all(y$H_R_unconf == 0))
@@ -274,9 +267,8 @@ test_that("No one is hospitalised, no-one recovers in edge case 2", {
   y0[info$index$I_A] <- 0
 
   mod$set_state(y0)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(any(y$I_C > 0))
   expect_true(all(y$H_R_unconf == 0))
@@ -309,9 +301,8 @@ test_that("No one dies in the community if psi_G_D is 0", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(any(y$I_C > 0))
   expect_true(all(y$G_D == 0))
@@ -345,9 +336,8 @@ test_that("forcing hospital route results in correct path", {
     mod <- carehomes$new(p, 0, 1)
     info <- mod$info()
     mod$set_state(carehomes_initial(info, 1, p)$state)
-    mod$set_index(integer(0))
     y <- mod$transform_variables(
-      drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+      drop(mod$simulate(seq(0, 400, by = 4))))
 
     ## Save some work by using the total of confirmed and unconfirmed
     y$H_R <- y$H_R_unconf + y$H_R_conf
@@ -406,9 +396,8 @@ test_that("No one seroconverts if p_sero_pos is 0", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(any(y$T_sero_neg > 0))
   expect_true(all(y$T_sero_pos == 0))
@@ -428,9 +417,8 @@ test_that("No one does not seroconvert and no one seroreverts
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(all(y$T_sero_neg == 0))
   expect_true(any(y$T_sero_pos > 0))
@@ -451,8 +439,7 @@ test_that("T_sero_pre parameters work as expected", {
     y0[info$index$T_sero_pre] <- 0
 
     mod$set_state(y0)
-    mod$set_index(integer(0))
-    mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+    mod$transform_variables(drop(mod$simulate(0:400)))
   }
 
   ## p_sero_pre_1 = 1, expect no cases in T_sero_pre_2 stream
@@ -520,8 +507,7 @@ test_that("setting a gamma to Inf results immediate progression", {
     }
 
     mod$set_state(state)
-    mod$set_index(integer(0))
-    y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+    y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
     if (hosp_compartment) {
       y[[compartment_name]] <- y[[name_conf]] + y[[name_unconf]]
@@ -595,8 +581,7 @@ test_that("setting a gamma to 0 results in no progression", {
     }
 
     mod$set_state(state)
-    mod$set_index(integer(0))
-    y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+    y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
     if (hosp_compartment) {
       y[[compartment_name]] <- y[[name_conf]] + y[[name_unconf]]
@@ -650,8 +635,7 @@ test_that("No one is unconfirmed, if p_star = 1", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state, 0)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   expect_true(all(y$H_R_unconf == 0))
   expect_true(any(y$H_R_conf > 0))
@@ -689,8 +673,7 @@ test_that("No one is confirmed, if p_star = 0 and gamma_U = 0", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state, 0)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
 
   expect_true(any(y$H_R_unconf > 0))
   expect_true(all(y$H_R_conf == 0))
@@ -739,8 +722,7 @@ test_that("Instant confirmation if p_star = 0 and gamma_U = Inf", {
   y0[info$index$ICU_D_unconf[1:19]] <- 50
 
   mod$set_state(y0, 0)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(dust::dust_iterate(mod, 0:400)))
+  y <- mod$transform_variables(drop(mod$simulate(0:400)))
   n <- length(y$time)
 
   ## Check hosp_R
@@ -803,9 +785,8 @@ test_that("tots all summed correctly ", {
   info <- mod$info()
   y0 <- carehomes_initial(info, 1, p)$state
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    drop(mod$simulate(seq(0, 400, by = 4))))
   expect_true(all(y$general_tot == apply(y$ICU_pre_conf, 5, sum) +
                     apply(y$H_R_conf, 5, sum) +
                     apply(y$H_D_conf, 5, sum) +

--- a/tests/testthat/test-carehomes-support.R
+++ b/tests/testthat/test-carehomes-support.R
@@ -542,10 +542,9 @@ test_that("model_pcr_and_serology_user switch works", {
   state <- carehomes_initial(info, 1, p)$state
 
   mod$set_state(state)
-  mod$set_index(integer(0))
 
   y <- mod$transform_variables(drop(
-    dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    mod$simulate(seq(0, 400, by = 4))))
 
   ## y$T_sero_neg and y$T_PCR_neg are increasing over time as noone gets out
   for (i in seq_len(p$n_groups)) {

--- a/tests/testthat/test-carehomes-vaccination.R
+++ b/tests/testthat/test-carehomes-vaccination.R
@@ -21,8 +21,8 @@ test_that("No infections with perfect vaccine wrt rel_susceptibility", {
   state[index_S[, 1]] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  s <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$S)
+  mod$set_index(info$index$S)
+  s <- mod$simulate(seq(0, 400, by = 4))
 
   ## Reshape to show the full shape of s
   expect_equal(length(s), prod(info$dim$S) * 101)
@@ -58,9 +58,7 @@ test_that("No symptomatic infections with perfect vaccine wrt rel_p_sympt", {
   state[index_S[, 1]] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(
-    dust::dust_iterate(mod, seq(0, 400, by = 4))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 4))))
 
   ## Noone moves into I_C ever
   ## other than in the 4th age group where some infections are seeded
@@ -92,9 +90,7 @@ test_that("Noone hospitalised with perfect vaccine wrt rel_p_hosp_if_sympt", {
   state[index_S[, 1]] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(
-    dust::dust_iterate(mod, seq(0, 400, by = 4))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 4))))
 
   ## Noone moves into hospitalised compartments ever
   ## other than in the 4th age group where some infections are seeded
@@ -132,8 +128,8 @@ test_that("No infections with perfect vaccine wrt rel_infectivity", {
   state[index_I_A[, 1, 1, 1]] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  s <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$S)
+  mod$set_index(info$index$S)
+  s <- mod$simulate(seq(0, 400, by = 4))
 
   ## Reshape to show the full shape of s
   expect_equal(length(s), prod(info$dim$S) * 101)
@@ -165,9 +161,7 @@ test_that("Vaccination of susceptibles works", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(
-    dust::dust_iterate(mod, seq(0, 400, by = 4))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 4))))
   i <- 4:carehomes_n_groups()
   expect_equal(y$S[i, 1, 1], y$S[i, 2, 2] + rowSums(y$E[i, , , 1, 2]))
   expect_equal(y$S[i, , 101], y$S[i, , 2])
@@ -202,8 +196,8 @@ test_that("Vaccination of exposed individuals works", {
   state[index_S] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  e <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$E)
+  mod$set_index(info$index$E)
+  e <- mod$simulate(seq(0, 400, by = 4))
 
   ## Reshape to show the full shape of e
   expect_equal(length(e), prod(info$dim$E) * 101)
@@ -257,9 +251,8 @@ test_that("Vaccination of asymptomatic infectious individuals works", {
   state[index_S] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  i_A <-
-    dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$I_A)
+  mod$set_index(info$index$I_A)
+  i_A <- mod$simulate(seq(0, 400, by = 4))
 
   ## Reshape to show the full shape of i_A
   expect_equal(length(i_A), prod(info$dim$I_A) * 101)
@@ -311,8 +304,8 @@ test_that("Vaccination of recovered individuals works", {
   state[index_I_A] <- 0 # remove seeded infections
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  r <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$R)
+  mod$set_index(info$index$R)
+  r <- mod$simulate(seq(0, 400, by = 4))
 
   ## Reshape to show the full shape of r
   expect_equal(length(r), prod(info$dim$R) * 101)
@@ -359,8 +352,8 @@ test_that("Returning to unvaccinated stage works for exposed individuals", {
   state[index_S] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  e <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$E)
+  mod$set_index(info$index$E)
+  e <- mod$simulate(seq(0, 400, by = 4))
 
   ## Reshape to show the full shape of e
   expect_equal(length(e), prod(info$dim$E) * 101)
@@ -414,9 +407,8 @@ test_that("Returning to unvaccinated stage works for I_A individuals", {
   state[index_S] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  i_A <- dust::dust_iterate(mod, seq(0, 400, by = 4),
-                                 info$index$I_A)
+  mod$set_index(info$index$I_A)
+  i_A <- mod$simulate(seq(0, 400, by = 4))
 
   ## Reshape to show the full shape of i_A
   expect_equal(length(i_A), prod(info$dim$I_A) * 101)
@@ -469,9 +461,8 @@ test_that("Returning to unvaccinated stage works for recovered individuals", {
   state[index_I_A] <- 0 # remove seeded infections
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  r <- dust::dust_iterate(mod, seq(0, 400, by = 4),
-                          info$index$R)
+  mod$set_index(info$index$R)
+  r <- mod$simulate(seq(0, 400, by = 4))
 
   ## Reshape to show the full shape of r
   expect_equal(length(r), prod(info$dim$R) * 101)
@@ -505,10 +496,8 @@ test_that("Vaccine progression through 3 classes works for susceptibles", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
   i <- 4:carehomes_n_groups()
-  y <- mod$transform_variables(drop(
-    dust::dust_iterate(mod, seq(0, 400, by = 4))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 4))))
   expect_equal(y$S[i, 1, 1], y$S[i, 3, 2])
   expect_equal(y$S[i, , 101], y$S[i, , 2])
 })
@@ -531,9 +520,7 @@ test_that("Vaccine progression through 12 classes works for susceptibles", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(drop(
-    dust::dust_iterate(mod, seq(0, 400, by = 12))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 12))))
   i <- 4:carehomes_n_groups()
   expect_equal(y$S[i, 1, 1], y$S[i, 12, 2])
   expect_equal(y$S[i, , 34], y$S[i, , 2])
@@ -574,8 +561,8 @@ test_that("Clinical progression within a vaccination class works", {
     state[index_S[, 3]]
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  y <- dust::dust_iterate(mod, seq(0, 400, by = 4), index)
+  mod$set_index(index)
+  y <- mod$simulate(seq(0, 400, by = 4))
 
   ## Reshape to show the full shape of s
   expect_equal(length(y),
@@ -611,8 +598,8 @@ test_that("Returning to unvaccinated stage works for susceptibles", {
   state[index_S[, 1]] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  s <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$S)
+  mod$set_index(info$index$S)
+  s <- mod$simulate(seq(0, 400, by = 4))
 
   ## Reshape to show the full shape of s
   expect_equal(length(s), prod(info$dim$S) * 101)
@@ -638,8 +625,8 @@ test_that("there are no vaccinated susceptibles when vaccination rate is 0", {
   mod <- carehomes$new(p, 0, 1)
   info <- mod$info()
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  s <- dust::dust_iterate(mod, seq(0, 400, by = 4), info$index$S)
+  mod$set_index(info$index$S)
+  s <- mod$simulate(seq(0, 400, by = 4))
 
   ## No vaccinated susceptibles:
   expect_equal(s[-seq_len(carehomes_n_groups()), , ],
@@ -666,7 +653,8 @@ test_that("Can calculate Rt with an (empty) vaccination class", {
   steps <- seq(initial$step, end, by = 1 / p$dt)
 
   set.seed(1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
 
   rt_1 <- carehomes_Rt(steps, y[, 1, ], p)
   rt_all <- carehomes_Rt_trajectories(steps, y, p)
@@ -689,7 +677,8 @@ test_that("Can calculate Rt with an (empty) vaccination class", {
   steps <- seq(initial$step, end, by = 1 / p$dt)
 
   set.seed(1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
 
   rt_1_single_class <- carehomes_Rt(steps, y[, 1, ], p)
   rt_all_single_class <- carehomes_Rt_trajectories(steps, y, p)
@@ -723,7 +712,8 @@ test_that("Effective Rt reduced by rel_susceptibility if all vaccinated", {
   steps <- seq(initial$step, end, by = 1 / p$dt)
 
   set.seed(1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
 
   rt_1 <- carehomes_Rt(steps, y[, 1, ], p)
   rt_all <- carehomes_Rt_trajectories(steps, y, p)
@@ -774,7 +764,8 @@ test_that("Effective Rt reduced by rel_infectivity if all vaccinated", {
   steps <- seq(initial$step, end, by = 1 / p$dt)
 
   set.seed(1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
 
   rt_1 <- carehomes_Rt(steps, y[, 1, ], p)
   rt_all <- carehomes_Rt_trajectories(steps, y, p)
@@ -833,7 +824,8 @@ test_that("Effective Rt modified if rel_p_sympt is not 1", {
   steps <- seq(initial$step, end, by = 1 / p$dt)
 
   set.seed(1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
 
   rt_1 <- carehomes_Rt(steps, y[, 1, ], p)
   rt_all <- carehomes_Rt_trajectories(steps, y, p)
@@ -883,7 +875,8 @@ test_that("Effective Rt modified if rel_p_hosp_if_sympt is not 1", {
   steps <- seq(initial$step, end, by = 1 / p$dt)
 
   set.seed(1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
 
   rt_1 <- carehomes_Rt(steps, y[, 1, ], p)
   rt_all <- carehomes_Rt_trajectories(steps, y, p)
@@ -930,7 +923,8 @@ test_that("Can calculate IFR_t with an (empty) vaccination class", {
   steps <- seq(initial$step, end, by = 1 / p$dt)
 
   set.seed(1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
   S <- y[seq_len(length(index_S)), , ]
   I_weighted <- y[-seq_len(length(index_S)), , ]
 
@@ -957,7 +951,8 @@ test_that("Can calculate IFR_t with an (empty) vaccination class", {
   steps <- seq(initial$step, end, by = 1 / p$dt)
 
   set.seed(1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
   S <- y[seq_len(length(index_S)), , ]
   I_weighted <- y[-seq_len(length(index_S)), , ]
 
@@ -996,7 +991,8 @@ test_that("IFR_t modified if rel_p_sympt is not 1", {
   steps <- seq(initial$step, end, by = 1 / p$dt)
 
   set.seed(1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
   S <- y[seq_len(length(index_S)), , ]
   I_weighted <- y[-seq_len(length(index_S)), , ]
 
@@ -1061,7 +1057,8 @@ test_that("IFR_t modified if rel_p_hosp_if_sympt is not 1", {
   steps <- seq(initial$step, end, by = 1 / p$dt)
 
   set.seed(1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
   S <- y[seq_len(length(index_S)), , ]
   I_weighted <- y[-seq_len(length(index_S)), , ]
 
@@ -1115,9 +1112,7 @@ test_that("N_tot, N_tot2 and N_tot3 stay constant with vaccination", {
   info <- mod$info()
   y0 <- carehomes_initial(info, 1, p)$state
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 4))))
 
   expect_true(all(y$N_tot3 - mod$transform_variables(y0)$N_tot3 == 0))
   expect_true(all(y$N_tot2 - mod$transform_variables(y0)$N_tot2 == 0))
@@ -1146,9 +1141,7 @@ test_that(
     info <- mod$info()
     y0 <- carehomes_initial(info, 1, p)$state
     mod$set_state(carehomes_initial(info, 1, p)$state)
-    mod$set_index(integer(0))
-    y <- mod$transform_variables(
-      drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+    y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 4))))
 
     expect_true(all(y$N_tot3 - mod$transform_variables(y0)$N_tot3 == 0))
     expect_true(all(y$N_tot2 - mod$transform_variables(y0)$N_tot2 == 0))
@@ -1169,9 +1162,7 @@ test_that("Outputed vaccination numbers make sense", {
   info <- mod$info()
   y0 <- carehomes_initial(info, 1, p)$state
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 4))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 4))))
 
   ## check outputed objects have correct dimension
   expect_equal(dim(y$cum_n_S_vaccinated), c(19, 3, 101))
@@ -1201,9 +1192,7 @@ test_that("Outputed S vaccination numbers are what we expect", {
   info <- mod$info()
   y0 <- carehomes_initial(info, 1, p)$state
   mod$set_state(carehomes_initial(info, 1, p)$state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 41))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 41))))
 
   i <- 4:carehomes_n_groups()
 
@@ -1242,9 +1231,7 @@ test_that("Outputed E vaccination numbers are what we expect", {
   state[index_S] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 41))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 41))))
 
   i <- 4:carehomes_n_groups()
   ## there are candidates in E for vaccination
@@ -1279,9 +1266,7 @@ test_that("Outputed I_A vaccination numbers are what we expect", {
   state[index_S] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 41))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 41))))
 
   i <- 4:carehomes_n_groups()
   ## there are candidates in I_A for vaccination
@@ -1317,9 +1302,7 @@ test_that("Outputed R vaccination numbers are what we expect", {
   state[index_S] <- 0
 
   mod$set_state(state)
-  mod$set_index(integer(0))
-  y <- mod$transform_variables(
-    drop(dust::dust_iterate(mod, seq(0, 400, by = 41))))
+  y <- mod$transform_variables(drop(mod$simulate(seq(0, 400, by = 41))))
 
   i <- 4:carehomes_n_groups()
   ## there are candidates in R for vaccination
@@ -1520,7 +1503,8 @@ test_that("run sensible vaccination schedule", {
             "cum_n_R_vaccinated")
   index <- unlist(lapply(info$index[keep], "[", 1:19), FALSE, FALSE)
 
-  y <- dust::dust_iterate(mod, seq(0, 380, by = 4), index)
+  mod$set_index(index)
+  y <- mod$simulate(seq(0, 380, by = 4))
   s <- array(y, c(19, 4, dim(y)[3]))
 
   ## Never vaccinate any young person:

--- a/tests/testthat/test-carehomes.R
+++ b/tests/testthat/test-carehomes.R
@@ -94,7 +94,8 @@ test_that("incidence calculation is correct", {
   expect_length(index, 14) # guard against name changes
 
   steps <- seq(initial$step, length.out = 60 * 4 + 1)
-  y <- dust::dust_iterate(mod, steps, index)
+  mod$set_index(index)
+  y <- mod$simulate(steps)
 
   i <- which(steps %% pars$steps_per_day == 0)
   j <- seq(1, 14, by = 2)

--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -109,13 +109,16 @@ test_that("Basic simulation", {
     beta_value = c(p$beta_step, p$beta_step, 0))
   p_cmp$beta_step[seq_len(length(p_cmp$beta_step) - 1)] <- p$beta_step
   step <- attr(res, "step")
-  cmp <- suppressWarnings(
-    dust::dust_simulate(basic, step, rep(list(p_cmp), np), state,
-                        seed = 1L, return_state = TRUE))
 
+  obj <- basic$new(rep(list(p_cmp), np), step[[1]], 1L,
+                   seed = 1L, pars_multi = TRUE)
+  obj$set_state(array(state, c(nrow(state), 1, ncol(state))))
+  cmp <- obj$simulate(step)
+  dim(cmp) <- dim(cmp)[-2]
   expect_equal(res, cmp, check.attributes = FALSE)
-  expect_equal(attr(res, "state"), attr(cmp, "state"))
-  expect_equal(attr(res, "rng_state"), attr(cmp, "rng_state"))
+
+  expect_equal(attr(res, "state"), array(obj$state(), dim(state)))
+  expect_equal(attr(res, "rng_state"), obj$rng_state())
 })
 
 

--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -109,8 +109,9 @@ test_that("Basic simulation", {
     beta_value = c(p$beta_step, p$beta_step, 0))
   p_cmp$beta_step[seq_len(length(p_cmp$beta_step) - 1)] <- p$beta_step
   step <- attr(res, "step")
-  cmp <- dust::dust_simulate(basic, step, rep(list(p_cmp), np), state,
-                             seed = 1L, return_state = TRUE)
+  cmp <- suppressWarnings(
+    dust::dust_simulate(basic, step, rep(list(p_cmp), np), state,
+                        seed = 1L, return_state = TRUE))
 
   expect_equal(res, cmp, check.attributes = FALSE)
   expect_equal(attr(res, "state"), attr(cmp, "state"))


### PR DESCRIPTION
This PR adds no new features and does not change the interface. 

We've deprecated `dust::dust_simulate` and `dust::dust_iterate` which makes the tests in the package very noisy as there's lots of deprecation warnings. This PR migrates everything to the new interface.

I've left the sircovid_simulate function untouched in its interface but I expect it's about to get overhauled

It would have been done at the same time as #218 but that was done in a hurry.