### PR TITLE
Move time to last dimension in Rt calculation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.10.4
+Version: 0.10.5
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# sircovid 0.10.5
+
+* Return Rt values in same time order as everything else (#223)
+* Allow calculation of a single Rt time in trajectories
+
 # sircovid 0.10.3
 * Predefined vaccination schedule implemented
 

--- a/R/carehomes_rt.R
+++ b/R/carehomes_rt.R
@@ -444,11 +444,12 @@ calculate_Rt_trajectories <- function(calculate_Rt, step, S, pars, prob_strain,
     if (initial_step_from_parameters) {
       step[[1L]] <- pars[[i]]$initial_step
     }
+    Si <- mcstate::array_drop(S[, i, , drop = FALSE], 2L)
     if (is.null(prob_strain)) {
-      rt_1 <- calculate_Rt(step, S[, i, ], pars[[i]], type = type, ...)
+      rt_1 <- calculate_Rt(step, Si, pars[[i]], type = type, ...)
     } else {
-      rt_1 <- calculate_Rt(step, S[, i, ], pars[[i]], prob_strain[, i, ],
-                           type = type, ...)
+      psi <- mcstate::array_drop(prob_strain[, i, , drop = FALSE], 2L)
+      rt_1 <- calculate_Rt(step, Si, pars[[i]], psi, type = type, ...)
     }
     rt_1
   }

--- a/man/carehomes_Rt_trajectories.Rd
+++ b/man/carehomes_Rt_trajectories.Rd
@@ -15,7 +15,8 @@ carehomes_Rt_trajectories(
   interpolate_every = NULL,
   interpolate_critical_dates = NULL,
   interpolate_min = NULL,
-  eigen_method = "power_iteration"
+  eigen_method = "power_iteration",
+  new_style = FALSE
 )
 }
 \arguments{
@@ -67,6 +68,12 @@ interpolation and that will not work with fewer than 3 points.}
 
 \item{eigen_method}{The eigenvalue method to use (passed to
 \link[eigen1:eigen1]{eigen1::eigen1} as \code{method})}
+
+\item{new_style}{Logical, indicating if we should return the "new
+style" Rt values. These match the rest of the package with time
+being in the last dimension (so columns rather than rows) and do
+not create matricies from date and step. This will become the
+default eventually.}
 }
 \value{
 As for \code{\link[=carehomes_Rt]{carehomes_Rt()}}, except that every element is a

--- a/tests/testthat/test-carehomes-rt.R
+++ b/tests/testthat/test-carehomes-rt.R
@@ -341,5 +341,24 @@ test_that("Parameters affect Rt as expected", {
   helper("k_ICU_W_D", 1, 2)
   helper("k_ICU_W_R", 1, 2)
   helper("k_G_D", 1, 2)
+})
 
+
+test_that("Can return rt with new direction", {
+  d <- reference_data_rt()
+
+  p <- d$inputs$p
+  steps <- d$inputs$steps
+  y <- d$inputs$y
+
+  cmp <- carehomes_Rt_trajectories(steps, y, p, new_style = FALSE)
+  res <- carehomes_Rt_trajectories(steps, y, p, new_style = TRUE)
+
+  expect_setequal(names(cmp), names(res))
+  expect_equal(res$step, cmp$step[, 1])
+  expect_equal(res$date, cmp$date[, 1])
+
+  for (v in setdiff(names(cmp), c("step", "date"))) {
+    expect_equal(res[[v]], t(cmp[[v]]))
+  }
 })

--- a/tests/testthat/test-carehomes-rt.R
+++ b/tests/testthat/test-carehomes-rt.R
@@ -362,3 +362,34 @@ test_that("Can return rt with new direction", {
     expect_equal(res[[v]], t(cmp[[v]]))
   }
 })
+
+
+test_that("allow trajectories calculation with single timestep", {
+  d <- reference_data_rt()
+
+  p <- d$inputs$p
+  steps <- d$inputs$steps
+  y <- d$inputs$y
+
+  cmp <- carehomes_Rt_trajectories(steps, y, p)
+
+  i <- 6L
+  res1 <- carehomes_Rt_trajectories(steps[i], y[, , i, drop = FALSE], p,
+                                    initial_step_from_parameters = FALSE)
+  expect_equal(
+    res1,
+    structure(lapply(cmp, function(x) x[i, , drop = FALSE]),
+              class = "Rt_trajectories"))
+
+  res2 <- carehomes_Rt_trajectories(steps[i], y[, , i, drop = FALSE], p,
+                                    initial_step_from_parameters = FALSE,
+                                    new_style = TRUE)
+
+  expect_setequal(names(res1), names(res2))
+  expect_equal(res2$step, res1$step[, 1])
+  expect_equal(res2$date, res1$date[, 1])
+
+  for (v in setdiff(names(res1), c("step", "date"))) {
+    expect_equal(res2[[v]], t(res1[[v]]))
+  }
+})


### PR DESCRIPTION
Fixes a few issues found while working with the Rt calculations:

* Don't expand date/step into a matrix, this is just annoying
* Leave time in the last axis (so transpose the Rt matrices)
* Allow calculation of trajectories at single time point

The transpose issues are disruptive so I've put them behind a flag atm and we can work them through the tasks and deprecate as we go.

This is failing due to to dust not being up to date, but if #213 is close it makes sense get that in first then rebase this PR against that

Fixes #223 