### PR TITLE
fix Rt calculation for NA prob strain

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.10.35
+Version: 0.10.36
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# sircovid 0.10.36
+
+* Fixed Rt calculation for multistrain so that Rt is NA only in the steps where prob_strain is NA (previously all Rt set to NA if any prob_strain was NA)
+
 # sircovid 0.10.34
 
-* Fixed `carehomes_rt` function to have flexibility for multiple dimensions, given strains, age categories and vaccinations classes. 
+* Fixed `carehomes_rt` function to have flexibility for multiple dimensions, given strains, age categories and vaccinations classes.
 * test-support.R updated accordingly.
 
 # sircovid 0.10.32
@@ -15,7 +19,7 @@
 
 # sircovid 0.10.30
 
-* Parameters describing vaccine efficacy (`rel_susceptibility`, `rel_p_sympt`, `rel_p_hosp_if_sympt` and `rel_infectivity`) can now take array values for 
+* Parameters describing vaccine efficacy (`rel_susceptibility`, `rel_p_sympt`, `rel_p_hosp_if_sympt` and `rel_infectivity`) can now take array values for
 varying across age groups, vaccination classes, and pathogen strains.
 
 # sircovid 0.10.29

--- a/R/carehomes_rt.R
+++ b/R/carehomes_rt.R
@@ -66,8 +66,8 @@ carehomes_Rt <- function(step, S, p, prob_strain = NULL,
   ## deal with the prob_strain NA case at the beginning before any variables
   ##  are modified
   if (!is.null(prob_strain) && any(is.na(prob_strain))) {
-    which_nna <- !vapply(seq(ncol(prob_strain)),
-                        function(i) any(is.na(prob_strain[, i])), logical(1))
+    which_nna <- !vlapply(seq(ncol(prob_strain)),
+                          function(i) any(is.na(prob_strain[, i])))
 
     ## calculate Rt by first ignoring NA
     ret <- carehomes_Rt(step[which_nna], S[, which_nna], p,

--- a/R/carehomes_rt.R
+++ b/R/carehomes_rt.R
@@ -63,6 +63,39 @@ carehomes_Rt <- function(step, S, p, prob_strain = NULL,
                          eigen_method = "power_iteration", R = NULL,
                          weight_Rt = FALSE) {
 
+  ## deal with the prob_strain NA case at the beginning before any variables
+  ##  are modified
+  if (!is.null(prob_strain) && any(is.na(prob_strain))) {
+    which_nna <- !vapply(seq(ncol(prob_strain)),
+                        function(i) any(is.na(prob_strain[, i])), logical(1))
+
+    ## calculate Rt by first ignoring NA
+    ret <- carehomes_Rt(step[which_nna], S[, which_nna], p,
+                        prob_strain[, which_nna], type, interpolate_every,
+                        interpolate_critical_dates, interpolate_min,
+                        eigen_method, R[, which_nna], weight_Rt)
+
+    ## replace reduced step,date,beta with full values (no NA here)
+    ret$step <- step
+    ret$date <- step * p$dt
+    ret$beta <- beta <- sircovid_parameters_beta_expand(step, p$beta_step)
+
+    ## restore full length Rt with NAs when prob_strain is NA
+    for (i in 4:length(ret)) {
+      if (inherits(ret[[i]], "matrix")) {
+        base <- matrix(NA, length(step), 2)
+        base[which_nna, ] <- ret[[i]]
+        ret[[i]] <- base
+      } else {
+        base <- rep(NA, length(step))
+        base[which_nna] <- ret[[i]]
+        ret[[i]] <- base
+      }
+    }
+
+    return(ret)
+  }
+
   all_types <- c("eff_Rt_all", "eff_Rt_general", "Rt_all", "Rt_general")
   if (is.null(type)) {
     type <- all_types
@@ -76,7 +109,8 @@ carehomes_Rt <- function(step, S, p, prob_strain = NULL,
   }
 
   if (!is.null(interpolate_every)) {
-    interpolate_critical_index <- match(interpolate_critical_dates / p$dt, step)
+    interpolate_critical_index <- match(interpolate_critical_dates / p$dt,
+                                        step)
     step_index_split <- interpolate_grid_critical_x(seq_along(step),
                                                     interpolate_every,
                                                     interpolate_critical_index,
@@ -191,15 +225,6 @@ carehomes_Rt <- function(step, S, p, prob_strain = NULL,
   mt[ch, ch, ] <- m[ch, ch]
 
   n_time <- length(step)
-
-  if (any(is.na(prob_strain))) {
-    ret <- list(step = step,
-                date = step * p$dt,
-                beta = beta)
-    ret[type] <- list(rep(NA_real_, length(step)))
-    class(ret) <- "Rt"
-    return(ret)
-  }
 
   mean_duration <-
     carehomes_Rt_mean_duration_weighted_by_infectivity(step, p)

--- a/R/carehomes_rt.R
+++ b/R/carehomes_rt.R
@@ -81,7 +81,7 @@ carehomes_Rt <- function(step, S, p, prob_strain = NULL,
     ret$beta <- beta <- sircovid_parameters_beta_expand(step, p$beta_step)
 
     ## restore full length Rt with NAs when prob_strain is NA
-    for (i in 4:length(ret)) {
+    for (i in grep("Rt_", names(ret))) {
       if (inherits(ret[[i]], "matrix")) {
         base <- matrix(NA, length(step), 2)
         base[which_nna, ] <- ret[[i]]

--- a/tests/testthat/test-carehomes-multistrain.R
+++ b/tests/testthat/test-carehomes-multistrain.R
@@ -1293,7 +1293,7 @@ test_that("If prob_strain is NA then Rt is NA ", {
   prob_strain <- y[index_prob_strain, , ]
 
   ## set NA for prob_strain in steps 60-70
-  prob_strain[,, 60:70] <- NA
+  prob_strain[, , 60:70] <- NA
 
   expect_true(!any(is.na(prob_strain[, , - (60:70)])))
   expect_true(all(is.na(prob_strain[, , 60:70])))
@@ -1306,11 +1306,11 @@ test_that("If prob_strain is NA then Rt is NA ", {
   ## all values of Rt in 60:70 to be NA and others not to be
   expect_vector_equal(lengths(rt_1[1:3]), 85)
   expect_true(all(is.na(simplify2array(rt_1[4:7])[60:70, , ])))
-  expect_true(!any(is.na(simplify2array(rt_1[4:7])[-(60:70),,])))
+  expect_true(!any(is.na(simplify2array(rt_1[4:7])[- (60:70), , ])))
 
   expect_equal(dim(simplify2array(rt_all[1:3])), c(85, 3, 3))
   expect_true(all(is.na(simplify2array(rt_all[4:7])[60:70, , , ])))
-  expect_true(!any(is.na(simplify2array(rt_all[4:7])[-(60:70),,,])))
+  expect_true(!any(is.na(simplify2array(rt_all[4:7])[- (60:70), , , ])))
 
 
   ## test weighted
@@ -1323,11 +1323,11 @@ test_that("If prob_strain is NA then Rt is NA ", {
   ## all values of Rt in 60:70 to be NA and others not to be
   expect_vector_equal(lengths(rt_1[1:3]), 85)
   expect_true(all(is.na(simplify2array(rt_1[4:7])[60:70, ])))
-  expect_true(!any(is.na(simplify2array(rt_1[4:7])[-(60:70), ])))
+  expect_true(!any(is.na(simplify2array(rt_1[4:7])[- (60:70), ])))
 
   expect_equal(dim(simplify2array(rt_all[1:3])), c(85, 3, 3))
   expect_true(all(is.na(simplify2array(rt_all[4:7])[60:70, , ])))
-  expect_true(!any(is.na(simplify2array(rt_all[4:7])[-(60:70), , ])))
+  expect_true(!any(is.na(simplify2array(rt_all[4:7])[- (60:70), , ])))
 })
 
 

--- a/tests/testthat/test-carehomes-multistrain.R
+++ b/tests/testthat/test-carehomes-multistrain.R
@@ -1266,7 +1266,7 @@ test_that("Can calculate Rt with a second variant with longer I_C_1", {
 })
 
 
-test_that("If prob_strain is NA then Rt is NA ", {
+test_that("If prob_strain is NA then Rt is NA only in same steps", {
   ## Run model with 2 variants, but both have same transmissibility
   ## no seeding for second variant so noone infected with that one
   p <- carehomes_parameters(sircovid_date("2020-02-07"), "england",
@@ -1293,10 +1293,11 @@ test_that("If prob_strain is NA then Rt is NA ", {
   prob_strain <- y[index_prob_strain, , ]
 
   ## set NA for prob_strain in steps 60-70
-  prob_strain[, , 60:70] <- NA
+  na_steps <- 60:70
+  prob_strain[, , na_steps] <- NA
 
-  expect_true(!any(is.na(prob_strain[, , - (60:70)])))
-  expect_true(all(is.na(prob_strain[, , 60:70])))
+  expect_true(!any(is.na(prob_strain[, , -na_steps])))
+  expect_true(all(is.na(prob_strain[, , na_steps])))
 
   ## test unweighted
 
@@ -1305,12 +1306,12 @@ test_that("If prob_strain is NA then Rt is NA ", {
 
   ## all values of Rt in 60:70 to be NA and others not to be
   expect_vector_equal(lengths(rt_1[1:3]), 85)
-  expect_true(all(is.na(simplify2array(rt_1[4:7])[60:70, , ])))
-  expect_true(!any(is.na(simplify2array(rt_1[4:7])[- (60:70), , ])))
+  expect_true(all(is.na(simplify2array(rt_1[4:7])[na_steps, , ])))
+  expect_true(!any(is.na(simplify2array(rt_1[4:7])[-na_steps, , ])))
 
   expect_equal(dim(simplify2array(rt_all[1:3])), c(85, 3, 3))
-  expect_true(all(is.na(simplify2array(rt_all[4:7])[60:70, , , ])))
-  expect_true(!any(is.na(simplify2array(rt_all[4:7])[- (60:70), , , ])))
+  expect_true(all(is.na(simplify2array(rt_all[4:7])[na_steps, , , ])))
+  expect_true(!any(is.na(simplify2array(rt_all[4:7])[-na_steps, , , ])))
 
 
   ## test weighted
@@ -1322,12 +1323,12 @@ test_that("If prob_strain is NA then Rt is NA ", {
 
   ## all values of Rt in 60:70 to be NA and others not to be
   expect_vector_equal(lengths(rt_1[1:3]), 85)
-  expect_true(all(is.na(simplify2array(rt_1[4:7])[60:70, ])))
-  expect_true(!any(is.na(simplify2array(rt_1[4:7])[- (60:70), ])))
+  expect_true(all(is.na(simplify2array(rt_1[4:7])[na_steps, ])))
+  expect_true(!any(is.na(simplify2array(rt_1[4:7])[-na_steps, ])))
 
   expect_equal(dim(simplify2array(rt_all[1:3])), c(85, 3, 3))
-  expect_true(all(is.na(simplify2array(rt_all[4:7])[60:70, , ])))
-  expect_true(!any(is.na(simplify2array(rt_all[4:7])[- (60:70), , ])))
+  expect_true(all(is.na(simplify2array(rt_all[4:7])[na_steps, , ])))
+  expect_true(!any(is.na(simplify2array(rt_all[4:7])[-na_steps, , ])))
 })
 
 

--- a/tests/testthat/test-carehomes-multistrain.R
+++ b/tests/testthat/test-carehomes-multistrain.R
@@ -1270,16 +1270,13 @@ test_that("If prob_strain is NA then Rt is NA ", {
   ## Run model with 2 variants, but both have same transmissibility
   ## no seeding for second variant so noone infected with that one
   p <- carehomes_parameters(sircovid_date("2020-02-07"), "england",
-                            strain_transmission = c(1, 1),
-                            cross_immunity = 0)
+                            strain_transmission = c(1, 1))
 
   np <- 3L
   mod <- carehomes$new(p, 0, np, seed = 1L)
 
-  ## Remove the initial infectives so that no-one becomes infected
   info <- mod$info()
   initial <- carehomes_initial(info, 1, p)
-  initial$state[info$index$I_A] <- 0
 
   mod$set_state(initial$state, initial$step)
   index_S <- mod$info()$index$S
@@ -1295,22 +1292,42 @@ test_that("If prob_strain is NA then Rt is NA ", {
   R <- y[index_R, , ]
   prob_strain <- y[index_prob_strain, , ]
 
-  ## all values of prob_strain after the first step should be NA
-  expect_true(all(is.na(prob_strain[, , -1L])))
+  ## set NA for prob_strain in steps 60-70
+  prob_strain[,, 60:70] <- NA
+
+  expect_true(!any(is.na(prob_strain[, , - (60:70)])))
+  expect_true(all(is.na(prob_strain[, , 60:70])))
+
+  ## test unweighted
 
   rt_1 <- carehomes_Rt(steps, S[, 1, ], p, prob_strain[, 1, ], R = R[, 1, ])
   rt_all <- carehomes_Rt_trajectories(steps, S, p, prob_strain, R = R)
 
-  ## all values of Rt after the first step should be NA
-  expect_true(all(is.na(rt_1$Rt_all[-1L])))
-  expect_true(all(is.na(rt_1$Rt_general[-1L])))
-  expect_true(all(is.na(rt_1$eff_Rt_all[-1L])))
-  expect_true(all(is.na(rt_1$eff_Rt_general[-1L])))
-  expect_true(all(is.na(rt_all$Rt_all[-1L, ])))
-  expect_true(all(is.na(rt_all$Rt_general[-1L, ])))
-  expect_true(all(is.na(rt_all$eff_Rt_all[-1L, ])))
-  expect_true(all(is.na(rt_all$eff_Rt_general[-1L, ])))
+  ## all values of Rt in 60:70 to be NA and others not to be
+  expect_vector_equal(lengths(rt_1[1:3]), 85)
+  expect_true(all(is.na(simplify2array(rt_1[4:7])[60:70, , ])))
+  expect_true(!any(is.na(simplify2array(rt_1[4:7])[-(60:70),,])))
 
+  expect_equal(dim(simplify2array(rt_all[1:3])), c(85, 3, 3))
+  expect_true(all(is.na(simplify2array(rt_all[4:7])[60:70, , , ])))
+  expect_true(!any(is.na(simplify2array(rt_all[4:7])[-(60:70),,,])))
+
+
+  ## test weighted
+
+  rt_1 <- carehomes_Rt(steps, S[, 1, ], p, prob_strain[, 1, ], R = R[, 1, ],
+                       weight_Rt = TRUE)
+  rt_all <- carehomes_Rt_trajectories(steps, S, p, prob_strain, R = R,
+                                      weight_Rt = TRUE)
+
+  ## all values of Rt in 60:70 to be NA and others not to be
+  expect_vector_equal(lengths(rt_1[1:3]), 85)
+  expect_true(all(is.na(simplify2array(rt_1[4:7])[60:70, ])))
+  expect_true(!any(is.na(simplify2array(rt_1[4:7])[-(60:70), ])))
+
+  expect_equal(dim(simplify2array(rt_all[1:3])), c(85, 3, 3))
+  expect_true(all(is.na(simplify2array(rt_all[4:7])[60:70, , ])))
+  expect_true(!any(is.na(simplify2array(rt_all[4:7])[-(60:70), , ])))
 })
 
 


### PR DESCRIPTION
Closes #276

Previously if any steps in prob_strain were NA then all Rt were NA, now Rt only NA in the same steps as prob_strain