### PR TITLE
add lag to vaccine schedule

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.10.48
+Version: 0.10.49
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# sircovid 0.10.49
+
+* Add `lag_groups` and `lag_days` parameters to `vaccine_schedule_future` to manually add lags for give age groups to the vaccine schedule
+
 # sircovid 0.10.47
 
 * New function `sircovid::inflate_state_strains` for adding empty strain compartments to a model state that was run without multiple strains

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # sircovid 0.10.49
 
-* Add `lag_groups` and `lag_days` parameters to `vaccine_schedule_future` to manually add lags for give age groups to the vaccine schedule
+* Add `lag_groups` and `lag_days` parameters to `vaccine_schedule_future` to manually add lags for given age groups to the vaccine schedule
 
 # sircovid 0.10.47
 

--- a/R/vaccination.R
+++ b/R/vaccination.R
@@ -436,14 +436,18 @@ vaccine_schedule_future <- function(start,
 
       ## get start of dose schedule for the group
       start <- which(old_schedule_group_i[1, ] > 0)[1]
-      ## initialize 0 array with same dimensions
-      new_schedule_group_i <- array(0, dim(old_schedule_group_i))
-      ## add dose schedule to new array after adding the given lag (also
-      ##  truncate end by lag amount)
-      new_schedule_group_i[, seq.int(start + lag_days, nc)] <-
-        old_schedule_group_i[, seq.int(start, nc - lag_days)]
-      ## save new schedule
-      schedule$doses[i, , ] <- new_schedule_group_i
+      ## catch case when groups are ineligible
+
+      if (!is.na(start)) {
+        ## initialize 0 array with same dimensions
+        new_schedule_group_i <- array(0, dim(old_schedule_group_i))
+        ## add dose schedule to new array after adding the given lag (also
+        ##  truncate end by lag amount)
+        new_schedule_group_i[, seq.int(start + lag_days, nc)] <-
+          old_schedule_group_i[, seq.int(start, nc - lag_days)]
+        ## save new schedule
+        schedule$doses[i, , ] <- new_schedule_group_i
+      }
     }
   }
 

--- a/R/vaccination.R
+++ b/R/vaccination.R
@@ -316,6 +316,7 @@ vaccine_priority_population <- function(region,
 ##' @param lag_groups Row indices, corresponding to age
 ##'   groups in which a lag should be added to the start time of the dose
 ##'   schedule returned by [vaccine_schedule], if NULL then no lag is added.
+##'   Ignored if `lag_groups` is NULL.
 ##'
 ##' @param lag_days If `lag_groups` is not NULL then specifies the number of
 ##'  days to add the start of the dose schedule for the given groups. Ignored
@@ -421,9 +422,9 @@ vaccine_schedule_future <- function(start,
 
   schedule <- vaccine_schedule(daily_doses_date, doses)
 
-  if (!is.null(lag_groups)) {
-    if (is.null(lag_days)) {
-      stop("'lag_days' must be non-NULL if 'lag_groups' is non_NULL")
+  if (!is.null(lag_groups) || !is.null(lag_days)) {
+    if (is.null(lag_days) || is.null(lag_groups)) {
+      stop("'lag_days' must be non-NULL iff 'lag_groups' is non_NULL")
     }
 
     ## we could do this in apply but loop is more readable

--- a/man/vaccine_schedule_future.Rd
+++ b/man/vaccine_schedule_future.Rd
@@ -8,7 +8,9 @@ vaccine_schedule_future(
   start,
   daily_doses_value,
   mean_days_between_doses,
-  priority_population
+  priority_population,
+  lag_groups = NULL,
+  lag_days = NULL
 )
 }
 \arguments{
@@ -24,6 +26,14 @@ and two}
 \item{priority_population}{Output from
 \link{vaccine_priority_population}, giving the number of people
 to vaccinate in each age (row) and priority group (column)}
+
+\item{lag_groups}{Row indices, corresponding to age
+groups in which a lag should be added to the start time of the dose
+schedule returned by \link{vaccine_schedule}, if NULL then no lag is added.}
+
+\item{lag_days}{If \code{lag_groups} is not NULL then specifies the number of
+days to add the start of the dose schedule for the given groups. Ignored
+if \code{lag_groups} is NULL.}
 }
 \description{
 Create future vaccination schedule from a projected number of

--- a/man/vaccine_schedule_scenario.Rd
+++ b/man/vaccine_schedule_scenario.Rd
@@ -9,7 +9,9 @@ vaccine_schedule_scenario(
   doses_future,
   end_date,
   mean_days_between_doses,
-  priority_population
+  priority_population,
+  lag_groups = NULL,
+  lag_days = NULL
 )
 }
 \arguments{
@@ -29,6 +31,14 @@ and two}
 \item{priority_population}{Output from
 \link{vaccine_priority_population}, giving the number of people
 to vaccinate in each age (row) and priority group (column)}
+
+\item{lag_groups}{Row indices, corresponding to age
+groups in which a lag should be added to the start time of the dose
+schedule returned by \link{vaccine_schedule}, if NULL then no lag is added.}
+
+\item{lag_days}{If \code{lag_groups} is not NULL then specifies the number of
+days to add the start of the dose schedule for the given groups. Ignored
+if \code{lag_groups} is NULL.}
 }
 \value{
 A \link{vaccine_schedule} object

--- a/tests/testthat/test-carehomes-vaccination.R
+++ b/tests/testthat/test-carehomes-vaccination.R
@@ -2602,6 +2602,12 @@ test_that("Can add lag to vaccine schedule", {
     0, doses_future, mean_days_between_doses, n, lag_groups = lag_groups),
     "must be non-NULL")
 
+  expect_error(vaccine_schedule_future(
+    0, doses_future, mean_days_between_doses, n, lag_groups = NULL,
+    lag_days = lag_days),
+    "must be non-NULL")
+
+
   vacc_schedule_no_lag <- vaccine_schedule_future(
     0, doses_future, mean_days_between_doses, n)
 

--- a/tests/testthat/test-carehomes-vaccination.R
+++ b/tests/testthat/test-carehomes-vaccination.R
@@ -2607,6 +2607,17 @@ test_that("Can add lag to vaccine schedule", {
     lag_days = lag_days),
     "must be non-NULL")
 
+  ## does nothing for ineligible groups
+  uptake_by_age_excl_3 <- c(numeric(3), rep(1, 16))
+  n_excl_3 <- vaccine_priority_population(region, uptake_by_age_excl_3)
+  vacc_schedule_no_lag <- vaccine_schedule_future(
+    0, doses_future, mean_days_between_doses, n_excl_3)
+  vacc_schedule_lag <- vaccine_schedule_future(
+    0, doses_future, mean_days_between_doses, n_excl_3, lag_groups = 1:3,
+    lag_days = lag_days)
+
+  expect_equal(vacc_schedule_no_lag, vacc_schedule_lag)
+
 
   vacc_schedule_no_lag <- vaccine_schedule_future(
     0, doses_future, mean_days_between_doses, n)


### PR DESCRIPTION
* Adds params `lag_groups` and `lag_days` to control which age groups to add a lag of `lag_days` to for the start of the doses returned by vaccine_schedule