### PR TITLE
fix_multi_rt_interpolate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.11.3
+Version: 0.11.4
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# sircovid 0.11.4
+
+* Fix Rt calculations for multistrain models when including interpolation
 # sircovid 0.11.3
 
 * For simplicity, it is now assumed that individuals that progress through model compartments at a given time step cannot also move vaccine classes in that same step

--- a/R/utils.R
+++ b/R/utils.R
@@ -168,14 +168,22 @@ interpolate_grid_critical_x <- function(x, every, critical, min) {
 
 
 interpolate_grid_expand_y <- function(y, step_split) {
-  f <- function(i) {
-    x <- step_split[[i]]
-    stats::spline(x, y_split[[i]], xout = seq_range(x))$y
+  interpolate <- function(y, step_split) {
+    f <- function(i) {
+      x <- step_split[[i]]
+      stats::spline(x, y_split[[i]], xout = seq_range(x))$y
+    }
+    n <- lengths(step_split)
+    y_split <- Map(function(len, to) y[seq(length.out = len, to = to)],
+                  n, cumsum(n))
+    unlist(lapply(seq_along(step_split), f))
   }
-  n <- lengths(step_split)
-  y_split <- Map(function(len, to) y[seq(length.out = len, to = to)],
-                 n, cumsum(n))
-  unlist(lapply(seq_along(step_split), f))
+
+  if (!is.null(dim(y))) {
+    apply(y, 2, interpolate, step_split = step_split)
+  } else {
+    interpolate(y, step_split)
+  }
 }
 
 


### PR DESCRIPTION
Fixes a bug in Rt calculation for multistrain models for interpolation which was erroneously mixing strains