### PR TITLE
Prevent a nan when running deterministically

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,6 +28,7 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.11.29
+Version: 0.11.30
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/inst/dust/carehomes.cpp
+++ b/inst/dust/carehomes.cpp
@@ -3209,7 +3209,7 @@ public:
     }
     for (int i = 1; i <= shared->dim_vaccine_probability_doses_1; ++i) {
       for (int j = 1; j <= shared->dim_vaccine_probability_doses_2; ++j) {
-        internal.vaccine_probability_doses[i - 1 + shared->dim_vaccine_probability_doses_1 * (j - 1)] = std::min(internal.vaccine_attempted_doses[shared->dim_vaccine_attempted_doses_1 * (j - 1) + i - 1] / (real_t) internal.vaccine_n_candidates[shared->dim_vaccine_n_candidates_1 * (j - 1) + i - 1], static_cast<real_t>(1));
+        internal.vaccine_probability_doses[i - 1 + shared->dim_vaccine_probability_doses_1 * (j - 1)] = std::min((internal.vaccine_n_candidates[shared->dim_vaccine_n_candidates_1 * (j - 1) + i - 1] > 0 ? internal.vaccine_attempted_doses[shared->dim_vaccine_attempted_doses_1 * (j - 1) + i - 1] / (real_t) internal.vaccine_n_candidates[shared->dim_vaccine_n_candidates_1 * (j - 1) + i - 1] : 0), static_cast<real_t>(1));
       }
     }
     for (int i = 1; i <= shared->dim_aux_ICU_D_conf_1; ++i) {

--- a/inst/odin/carehomes.R
+++ b/inst/odin/carehomes.R
@@ -1674,7 +1674,8 @@ dim(vaccine_n_candidates) <- c(n_groups, n_doses)
 ## Work out the vaccination probability via doses, driven by the
 ## schedule
 vaccine_probability_doses[, ] <- min(
-  vaccine_attempted_doses[i, j] / vaccine_n_candidates[i, j],
+  if (vaccine_n_candidates[i, j] > 0)
+    vaccine_attempted_doses[i, j] / vaccine_n_candidates[i, j] else 0,
   as.numeric(1))
 dim(vaccine_probability_doses) <- c(n_groups, n_doses)
 

--- a/src/carehomes.cpp
+++ b/src/carehomes.cpp
@@ -3281,7 +3281,7 @@ public:
     }
     for (int i = 1; i <= shared->dim_vaccine_probability_doses_1; ++i) {
       for (int j = 1; j <= shared->dim_vaccine_probability_doses_2; ++j) {
-        internal.vaccine_probability_doses[i - 1 + shared->dim_vaccine_probability_doses_1 * (j - 1)] = std::min(internal.vaccine_attempted_doses[shared->dim_vaccine_attempted_doses_1 * (j - 1) + i - 1] / (real_t) internal.vaccine_n_candidates[shared->dim_vaccine_n_candidates_1 * (j - 1) + i - 1], static_cast<real_t>(1));
+        internal.vaccine_probability_doses[i - 1 + shared->dim_vaccine_probability_doses_1 * (j - 1)] = std::min((internal.vaccine_n_candidates[shared->dim_vaccine_n_candidates_1 * (j - 1) + i - 1] > 0 ? internal.vaccine_attempted_doses[shared->dim_vaccine_attempted_doses_1 * (j - 1) + i - 1] / (real_t) internal.vaccine_n_candidates[shared->dim_vaccine_n_candidates_1 * (j - 1) + i - 1] : 0), static_cast<real_t>(1));
       }
     }
     for (int i = 1; i <= shared->dim_aux_ICU_D_conf_1; ++i) {


### PR DESCRIPTION
Not totally sure why this doesn't turn up in stochastic mode, but it implies that rbinom(0, nan) => 0 normally whereas we do 0 * nan => nan which then when cast to integer is giving -INTEGER_MAX