### PR TITLE
Round booster population left

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.12.10
+Version: 0.12.11
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# sircovid 0.12.11
+
+* Ensure `booster_population_left` is rounded in `vaccine_schedule_future`
+
 # sircovid 0.12.10
 
 * `vaccine_schedule_from_data` function refactored to deal with flexible number of doses

--- a/R/vaccination.R
+++ b/R/vaccination.R
@@ -390,7 +390,7 @@ vaccine_schedule_future <- function(start,
     daily_doses_tt, daily_doses_value, population_left,
     population_to_vaccinate_mat, mean_days_between_doses, n_prev, 1:2)
   if (has_booster) {
-    booster_population_left <- population_left * booster_proportion
+    booster_population_left <- round(population_left * booster_proportion)
 
     population_to_vaccinate_mat <- vaccination_schedule_exec(
       daily_doses_tt, booster_daily_doses_value, booster_population_left,


### PR DESCRIPTION
Fixes a minor bug, where `booster_population_left` was not rounded in `vaccine_schedule_future` - causes problems if you get close to 0 left to vaccinate......ended up with negative doses, and an error thrown.