### PR TITLE
Patch rt cross immunity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.12.15
+Version: 0.12.16
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# sircovid 0.12.16
+
+* Corrected implementation of cross immunity in effective Rt calculation
+
 # sircovid 0.12.15
 
 * Fixed issue #365 and simulation to the UK level is now restored

--- a/R/lancelot_rt.R
+++ b/R/lancelot_rt.R
@@ -296,7 +296,8 @@ lancelot_Rt <- function(step, S, p, prob_strain = NULL,
             RR <- 0
           }
         }
-
+        ## We are calculating the NGM for strain i, so we need the cross
+        ## immunity of strain 3 - i (2 if i = 1, 1 if i = 2) against strain i
         compute_ngm(md, x, p$rel_susceptibility[, i, ], RR,
                     1 - p$cross_immunity[3 - i])
       }

--- a/R/lancelot_rt.R
+++ b/R/lancelot_rt.R
@@ -298,7 +298,7 @@ lancelot_Rt <- function(step, S, p, prob_strain = NULL,
         }
 
         compute_ngm(md, x, p$rel_susceptibility[, i, ], RR,
-                    1 - p$cross_immunity[i])
+                    1 - p$cross_immunity[3 - i])
       }
     }, array(0, c(n_groups * n_vacc_classes, n_groups * n_vacc_classes,
                   n_time)))

--- a/inst/odin/lancelot.R
+++ b/inst/odin/lancelot.R
@@ -477,6 +477,10 @@ n_I_P_vacc_skip[, , ] <-
 ##  R1 and R2 can progress to S (w.r. waning_rate[i]) or
 ##  R1 can progress to E3 (w.r. strain 2 (3 - 1))
 ##  R2 can progress tp E4 (w.r. strain 1 (3 - 2))
+##
+## Note that (if n_strains > 2)
+## cross_immunity[1] is the cross immunity of strain 1 against strain 2
+## cross_immunity[2] is the cross immunity of strain 2 against strain 1
 rate_R_progress[, , ] <- waning_rate[i] +
             if (n_strains == 1 || j > 2) 0 else
               lambda_susc[i, 3 - j, k] * (1 - cross_immunity[j])

--- a/inst/odin/lancelot.R
+++ b/inst/odin/lancelot.R
@@ -478,7 +478,7 @@ n_I_P_vacc_skip[, , ] <-
 ##  R1 can progress to E3 (w.r. strain 2 (3 - 1))
 ##  R2 can progress tp E4 (w.r. strain 1 (3 - 2))
 ##
-## Note that (if n_strains > 2)
+## Note that (if n_real_strains == 2)
 ## cross_immunity[1] is the cross immunity of strain 1 against strain 2
 ## cross_immunity[2] is the cross immunity of strain 2 against strain 1
 rate_R_progress[, , ] <- waning_rate[i] +

--- a/tests/testthat/test-lancelot-multistrain.R
+++ b/tests/testthat/test-lancelot-multistrain.R
@@ -2534,7 +2534,8 @@ test_that("Rt lower with perfect cross immunity", {
 })
 
 
-test_that("Strain 1 Rt lower with perfect cross immunity to strain 2", {
+test_that("Can calculate Rt with asymmetric cross immunity", {
+  ## Run with perfect cross immunity for both strains first
   p <- lancelot_parameters(sircovid_date("2020-02-07"), "england",
                            initial_seed_size = 10,
                            initial_seed_pattern = rep(1, 4),
@@ -2562,9 +2563,11 @@ test_that("Strain 1 Rt lower with perfect cross immunity to strain 2", {
   R <- y[index_R, , ]
   prob_strain <- y[index_prob_strain, , ]
 
-  rt_cross_1 <- lancelot_Rt(steps, S[, 1, ], p, prob_strain[, 1, ],
-                            R = R[, 1, ], weight_Rt = FALSE)
+  rt <- lancelot_Rt(steps, S[, 1, ], p, prob_strain[, 1, ],
+                    R = R[, 1, ], weight_Rt = FALSE)
 
+  ## Now calculate where strain 1 gives perfect immunity to strain 2,
+  ## and strain 2 gives no immunity to strain 1
   p <- lancelot_parameters(sircovid_date("2020-02-07"), "england",
                            initial_seed_size = 10,
                            initial_seed_pattern = rep(1, 4),
@@ -2574,23 +2577,43 @@ test_that("Strain 1 Rt lower with perfect cross immunity to strain 2", {
                            strain_seed_pattern = rep(1, 4),
                            cross_immunity = c(1, 0))
 
-  rt_cross_0 <- lancelot_Rt(steps, S[, 1, ], p, prob_strain[, 1, ],
-                            R = R[, 1, ], weight_Rt = FALSE)
+  rt1 <- lancelot_Rt(steps, S[, 1, ], p, prob_strain[, 1, ],
+                     R = R[, 1, ], weight_Rt = FALSE)
 
-  ## Rt should be equal
+  ## Rt should be unaffected
   tol <- 1e-5
-  expect_equal(rt_cross_1$Rt_all, rt_cross_0$Rt_all)
-  expect_equal(rt_cross_1$Rt_general, rt_cross_0$Rt_general)
-  ## eff_Rt should be equal for strain 2, lower for strain 1
-  expect_equal(rt_cross_1$eff_Rt_all[, 2], rt_cross_0$eff_Rt_all[, 2],
-               tol = tol)
-  expect_equal(rt_cross_1$eff_Rt_general[, 2], rt_cross_0$eff_Rt_general[, 2],
-               tol = tol)
-  expect_vector_lt(rt_cross_1$eff_Rt_all[, 1], rt_cross_0$eff_Rt_all[, 1],
-                   tol = tol)
-  expect_vector_lt(rt_cross_1$eff_Rt_general[, 1],
-                   rt_cross_0$eff_Rt_general[, 1],
-                   tol = tol)
+  expect_equal(rt1$Rt_all, rt$Rt_all)
+  expect_equal(rt1$Rt_general, rt$Rt_general)
+  ## eff_Rt should be unaffected for strain 2, increased for strain 1
+  expect_equal(rt1$eff_Rt_all[, 2], rt$eff_Rt_all[, 2], tol = tol)
+  expect_equal(rt1$eff_Rt_general[, 2], rt$eff_Rt_general[, 2], tol = tol)
+  expect_vector_gt(rt1$eff_Rt_all[, 1], rt$eff_Rt_all[, 1], tol = tol)
+  expect_vector_gt(rt1$eff_Rt_general[, 1], rt$eff_Rt_general[, 1], tol = tol)
+
+
+  ## Now calculate the other way round; where strain 2 gives perfect immunity
+  ## to strain 1, and strain 1 gives no immunity to strain 2
+  p <- lancelot_parameters(sircovid_date("2020-02-07"), "england",
+                           initial_seed_size = 10,
+                           initial_seed_pattern = rep(1, 4),
+                           strain_transmission = c(1, 1),
+                           strain_seed_date = sircovid_date("2020-02-07"),
+                           strain_seed_size = 10,
+                           strain_seed_pattern = rep(1, 4),
+                           cross_immunity = c(0, 1))
+
+  rt2 <- lancelot_Rt(steps, S[, 1, ], p, prob_strain[, 1, ],
+                     R = R[, 1, ], weight_Rt = FALSE)
+
+  ## Rt should be unaffected
+  tol <- 1e-5
+  expect_equal(rt2$Rt_all, rt$Rt_all)
+  expect_equal(rt2$Rt_general, rt$Rt_general)
+  ## eff_Rt should be unaffected for strain 1, increased for strain 2
+  expect_equal(rt2$eff_Rt_all[, 1], rt$eff_Rt_all[, 1], tol = tol)
+  expect_equal(rt2$eff_Rt_general[, 1], rt$eff_Rt_general[, 1], tol = tol)
+  expect_vector_gt(rt2$eff_Rt_all[, 2], rt$eff_Rt_all[, 2], tol = tol)
+  expect_vector_gt(rt2$eff_Rt_general[, 2], rt$eff_Rt_general[, 2], tol = tol)
 
 })
 


### PR DESCRIPTION
Patches up the Rt calculation wrt to cross immunity being implemented the wrong way round. Would only have affected the effective Rt calculated in post-processing (would not affect the Rt excluding immunity)