### PR TITLE
Add dummy argument to rotate strains

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.12.33
+Version: 0.12.34
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/tools.R
+++ b/R/tools.R
@@ -192,8 +192,14 @@ check_sircovid_model <- function(sircovid_model) {
 ##' @param state Model state
 ##'
 ##' @param info Model info
+##'
+##' @param ... Additional arguments, ignored. This exists so that this
+##'   function can be used as an argument to
+##'   [mcstate::multistage_epoch].  Practically your two model
+##'   informations in this case would be equivalent.
+##'
 ##' @export
-rotate_strains <- function(state, info) {
+rotate_strains <- function(state, info, ...) {
   if (is.null(dim(state))) {
     stop("Expected a matrix or array for 'state'")
   }

--- a/man/rotate_strains.Rd
+++ b/man/rotate_strains.Rd
@@ -4,12 +4,17 @@
 \alias{rotate_strains}
 \title{Rotate strains}
 \usage{
-rotate_strains(state, info)
+rotate_strains(state, info, ...)
 }
 \arguments{
 \item{state}{Model state}
 
 \item{info}{Model info}
+
+\item{...}{Additional arguments, ignored. This exists so that this
+function can be used as an argument to
+\link[mcstate:multistage_epoch]{mcstate::multistage_epoch}.  Practically your two model
+informations in this case would be equivalent.}
 }
 \description{
 Rotate strains, so that strain 1 becomes the sum of strains 1 and


### PR DESCRIPTION
This is needed in order to allow direct use of `sircovid::rotate_strains` from the `mcstate::multistage_parameter` calls.  That in turn is needed because otherwise the environment of the transform function is different for each region in the multiregion case, which is problematic.