### PR TITLE
Fix to work with mcstate 0.8.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sircovid
 Title: SIR Model for COVID-19
-Version: 0.12.31
+Version: 0.12.32
 Authors@R:
     c(person(given = "Marc",
            family = "Baguelin",

--- a/R/support.R
+++ b/R/support.R
@@ -442,17 +442,13 @@ reorder_sample <- function(sample, rank) {
     stop(paste("Unexpected length for 'rank':", length(rank),
                "; should have length", length(sample$iteration)))
   }
-
-  sample <- mcstate::pmcmc_thin(sample)
-  ## Workaround until Rich fixes mcstate:
-  sample$pars_index <- NULL
-
   if (!is.null(sample$chain)) {
     sample$chain <- sample$chain[rank]
   }
   ## This looks like a no-op, but acts to drop any "full" parameters
   ## (using mcstate 0.8.2 or later).  Without this, the
   ## pars/probability subsetting will behave unexpectedly.
+  sample <- mcstate::pmcmc_thin(sample)
   sample$iteration <- sample$iteration[rank]
   sample$pars <- sample$pars[rank, ]
   sample$probabilities <- sample$probabilities[rank, ]

--- a/R/support.R
+++ b/R/support.R
@@ -445,6 +445,10 @@ reorder_sample <- function(sample, rank) {
   if (!is.null(sample$chain)) {
     sample$chain <- sample$chain[rank]
   }
+  ## This looks like a no-op, but acts to drop any "full" parameters
+  ## (using mcstate 0.8.2 or later).  Without this, the
+  ## pars/probability subsetting will behave unexpectedly.
+  sample <- mcstate::pmcmc_thin(sample)
   sample$iteration <- sample$iteration[rank]
   sample$pars <- sample$pars[rank, ]
   sample$probabilities <- sample$probabilities[rank, ]

--- a/R/support.R
+++ b/R/support.R
@@ -442,13 +442,17 @@ reorder_sample <- function(sample, rank) {
     stop(paste("Unexpected length for 'rank':", length(rank),
                "; should have length", length(sample$iteration)))
   }
+
+  sample <- mcstate::pmcmc_thin(sample)
+  ## Workaround until Rich fixes mcstate:
+  sample$pars_index <- NULL
+
   if (!is.null(sample$chain)) {
     sample$chain <- sample$chain[rank]
   }
   ## This looks like a no-op, but acts to drop any "full" parameters
   ## (using mcstate 0.8.2 or later).  Without this, the
   ## pars/probability subsetting will behave unexpectedly.
-  sample <- mcstate::pmcmc_thin(sample)
   sample$iteration <- sample$iteration[rank]
   sample$pars <- sample$pars[rank, ]
   sample$probabilities <- sample$probabilities[rank, ]

--- a/tests/testthat/helper-lancelot.R
+++ b/tests/testthat/helper-lancelot.R
@@ -43,8 +43,8 @@ helper_lancelot_particle_filter <- function(data, n_particles,
     if (compiled_compare) NULL else lancelot_compare,
     lancelot_index,
     lancelot_initial,
-    n_threads,
-    seed)
+    n_threads = n_threads,
+    seed = seed)
 }
 
 


### PR DESCRIPTION
I've not tested this because it would require running the chains with thinning on, but I think this is the issue.  Can you please confirm @edknock?

I've not increased the min mcstate version number as this will work with both old and new versions.